### PR TITLE
Rename forever-winter theme to cyberpunk

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-theme="forever-winter">
+<html lang="en" data-theme="cyberpunk">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/src/index.css
+++ b/src/index.css
@@ -20,7 +20,7 @@ html, body, #root {
    JetBrains Mono. Zero border radius. Uppercase labels.
 ═════════════════════════════════════════════════════════════════════════ */
 :root,
-[data-theme="forever-winter"] {
+[data-theme="cyberpunk"] {
   --font:                'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
   --radius:              0px;
   --radius-btn:          0px;

--- a/src/services/ThemeService.ts
+++ b/src/services/ThemeService.ts
@@ -1,4 +1,4 @@
-export type ThemeName = 'forever-winter' | 'xbox' | 'playstation' | 'nintendo' | 'steam';
+export type ThemeName = 'cyberpunk' | 'xbox' | 'playstation' | 'nintendo' | 'steam';
 
 export interface Theme {
   name: ThemeName;
@@ -9,9 +9,9 @@ export interface Theme {
 }
 
 export const THEMES: Record<ThemeName, Theme> = {
-  'forever-winter': {
-    name: 'forever-winter',
-    displayName: 'Forever Winter',
+  cyberpunk: {
+    name: 'cyberpunk',
+    displayName: 'Cyberpunk',
     description: 'Dark military terminal. Amber glow. Zero mercy.',
     swatchBg: '#0d0e10',
     swatchAccent: '#c8a84b',
@@ -49,7 +49,7 @@ export const THEMES: Record<ThemeName, Theme> = {
 export class ThemeService {
   private static instance: ThemeService | null = null;
   private static readonly STORAGE_KEY = 'minigames_theme';
-  private currentTheme: ThemeName = 'forever-winter';
+  private currentTheme: ThemeName = 'cyberpunk';
   private listeners: ((theme: ThemeName) => void)[] = [];
 
   private constructor() {


### PR DESCRIPTION
Renames the `forever-winter` theme to `cyberpunk` across ThemeService, index.css, and index.html.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZSyiQENekom3uifApGQdN)_