### PR TITLE
Platform touch abstraction: GameButton + swipe auto-exclusion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,141 @@
+# Mini Games — Platform Guide
+
+## Stack
+
+React 19 + TypeScript 5.8 (`erasableSyntaxOnly` — no constructor parameter properties), Vite 7, Firebase Realtime DB for WebRTC signalling. Deploy: push to `main` → GitHub Actions → GitHub Pages.
+
+---
+
+## Adding a game
+
+1. Create `src/games/<id>/` with:
+   - `<Name>.tsx` — the React component (`playerId: string, playerName: string` props)
+   - `<Name>.game.ts` — implements `IGame<TState, TAction>` from `src/games/_contract/IGame.ts`
+   - `<Name>.css`
+   - `types.ts`, `gameLogic.ts`, `index.ts`
+2. Register in `src/components/game/GameContainer.tsx` (new `case` in the switch).
+3. Add an entry to `AVAILABLE_GAMES` in `src/components/game/GamesList.tsx`.
+
+### IGame contract
+
+```ts
+interface IGame<TState, TAction> {
+  id: string;
+  initialState(players: Player[]): TState;
+  reduce(state: TState, action: TAction, from: Player): TState | null;
+  canAct(state: TState, playerId: string): boolean;
+  validateSnapshot(raw: unknown): TState;   // throw on invalid
+}
+```
+
+`reduce` returns `null` to signal "action rejected, no state change".
+
+---
+
+## Multiplayer
+
+Host-authoritative star topology. The host runs the game loop and broadcasts full state snapshots to all guests after every tick or action.
+
+```ts
+const session = useSession();
+const isHost = !session.isInSession || session.role === 'host';
+```
+
+**Host pattern**
+```ts
+// Apply action and push state to all peers
+session.broadcastSnapshot(gameId, nextState);
+
+// Respond to late-joiner snapshot requests
+session.manager.on('game-snapshot-requested', ({ gameId, fromPeerId }) => {
+  session.sendSnapshot(gameId, currentState, fromPeerId);
+});
+
+// Receive guest actions
+session.manager.on('game-action', ({ gameId, action, from }) => { ... });
+```
+
+**Guest pattern**
+```ts
+// Pull current state on mount
+session.requestSnapshot(gameId);
+
+// Receive state from host
+session.manager.on('game-snapshot', ({ gameId, state }) => { ... });
+
+// Send actions to host
+session.sendAction(gameId, action);
+```
+
+Use a `useRef` to hold authoritative state in the host game-loop to avoid stale closures in `setInterval`.
+
+---
+
+## Touch events — critical rules
+
+### Problem
+
+`useSwipeGestures` registers a **non-passive** `touchstart` listener when `preventDefault: true`. On Android, calling `preventDefault()` in a touchstart listener suppresses the browser's synthetic `click` event — making any `<button onClick={...}>` inside the swipe container appear dead.
+
+### Platform-level fix (already in place)
+
+`useSwipeGestures` automatically excludes `button, a, input, select, textarea, [role="button"]` from `preventDefault` and swipe tracking. You do **not** need to add `excludeSelector` for standard interactive elements.
+
+### Use `GameButton` for all action buttons inside games
+
+```tsx
+import { GameButton } from '../../components/ui';
+
+// ✅ correct — fires on pointerdown, stops propagation
+<GameButton className="my-btn" onClick={handleStart}>Play</GameButton>
+
+// ❌ wrong — onClick may be silenced by ancestor swipe handler on mobile
+<button className="my-btn" onClick={handleStart}>Play</button>
+```
+
+`GameButton` is a drop-in `<button>` replacement that uses `onPointerDown` + `stopPropagation` internally, so it is immune to ancestor touch-event interference. Use it for every action button inside a game container.
+
+D-pad buttons should use `onPointerDown` directly (they're simple enough not to need the component):
+```tsx
+<button onPointerDown={() => changeDirection('up')}>↑</button>
+```
+
+### Swipe setup
+
+```ts
+useSwipeGestures(containerRef, {
+  onSwipeUp:    () => move('up'),
+  onSwipeDown:  () => move('down'),
+  onSwipeLeft:  () => move('left'),
+  onSwipeRight: () => move('right'),
+  minSwipeDistance: 25,
+  preventDefault: true,   // blocks page scroll while swiping
+  // excludeSelector only needed for non-button interactive areas
+});
+```
+
+---
+
+## Theming
+
+Five themes: `cyberpunk` (default), `xbox`, `playstation`, `nintendo`, `steam`.
+
+Themes are pure CSS (`[data-theme="x"]` blocks in `src/index.css`). `ThemeService` sets `document.documentElement.dataset.theme`. Use CSS custom properties everywhere:
+
+```css
+background: var(--color-surface);
+border-radius: var(--radius-btn);
+font-family: var(--font);
+text-transform: var(--ui-text-transform);
+```
+
+Never hardcode colors or radii in game CSS — theme tokens cover everything.
+
+---
+
+## File conventions
+
+- No constructor parameter properties (TS `erasableSyntaxOnly`).
+- No comments explaining what code does — only WHY when non-obvious.
+- `useRef` for values that need to be current inside intervals/callbacks without stale closures.
+- Canvas games: dark background (`#0a0b0d`) regardless of theme; grid lines at `rgba(255,255,255,0.04)`.

--- a/src/components/ui/GameButton.tsx
+++ b/src/components/ui/GameButton.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+interface GameButtonProps {
+  onClick: () => void;
+  className?: string;
+  disabled?: boolean;
+  style?: React.CSSProperties;
+  children: React.ReactNode;
+}
+
+/**
+ * Drop-in button replacement for use inside game containers that have swipe
+ * gesture handlers. Uses onPointerDown + stopPropagation so it fires immediately
+ * on touch without being suppressed by any ancestor non-passive touchstart listener.
+ *
+ * Use this instead of <button onClick={...}> for any action button inside a game.
+ */
+export const GameButton: React.FC<GameButtonProps> = ({
+  onClick,
+  className,
+  disabled,
+  style,
+  children,
+}) => (
+  <button
+    className={className}
+    disabled={disabled}
+    style={style}
+    onPointerDown={(e) => {
+      if (disabled) return;
+      e.stopPropagation();
+      onClick();
+    }}
+  >
+    {children}
+  </button>
+);
+
+export default GameButton;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,2 +1,3 @@
 export { NameEntry } from './NameEntry';
 export { Profile } from './Profile';
+export { GameButton } from './GameButton';

--- a/src/games/snake/Snake.tsx
+++ b/src/games/snake/Snake.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useCallback, useState } from 'react';
 import { useSession } from '../../hooks/useSession';
 import { useCoinService } from '../../hooks/useCoinService';
 import { useSwipeGestures } from '../../hooks/useSwipeGestures';
+import { GameButton } from '../../components/ui';
 import type { SnakeGameState, SnakeAction, Direction } from './types';
 import { snakeGame } from './Snake.game';
 import {
@@ -153,7 +154,7 @@ export const SnakeGame: React.FC<SnakeProps> = ({ playerId, playerName }) => {
     return () => window.removeEventListener('keydown', onKey);
   }, [changeDirection]);
 
-  // Swipe — exclude overlay so its buttons still receive click events on mobile
+  // Swipe — interactive elements (buttons etc.) are excluded automatically by the hook.
   useSwipeGestures(containerRef, {
     onSwipeUp:    () => changeDirection('up'),
     onSwipeDown:  () => changeDirection('down'),
@@ -161,7 +162,6 @@ export const SnakeGame: React.FC<SnakeProps> = ({ playerId, playerName }) => {
     onSwipeRight: () => changeDirection('right'),
     minSwipeDistance: 25,
     preventDefault: true,
-    excludeSelector: '.snake-overlay',
   });
 
   // ── Multiplayer wiring ─────────────────────────────────────────────────
@@ -363,11 +363,11 @@ export const SnakeGame: React.FC<SnakeProps> = ({ playerId, playerName }) => {
                 </div>
               )}
               {isHost ? (
-                <button className="snake-action-btn" onPointerDown={(e) => { e.stopPropagation(); handleStart(); }}>
+                <GameButton className="snake-action-btn" onClick={handleStart}>
                   {isInSession
                     ? `Start Game · ${allPlayers.length} player${allPlayers.length !== 1 ? 's' : ''}`
                     : 'Play Solo'}
-                </button>
+                </GameButton>
               ) : (
                 <p className="snake-waiting-msg">Waiting for host to start…</p>
               )}
@@ -397,9 +397,9 @@ export const SnakeGame: React.FC<SnakeProps> = ({ playerId, playerName }) => {
                   ))}
               </div>
               {isHost ? (
-                <button className="snake-action-btn" onPointerDown={(e) => { e.stopPropagation(); handleStart(); }}>
+                <GameButton className="snake-action-btn" onClick={handleStart}>
                   Play Again
-                </button>
+                </GameButton>
               ) : (
                 <p className="snake-waiting-msg">Waiting for host to restart…</p>
               )}

--- a/src/hooks/useSwipeGestures.ts
+++ b/src/hooks/useSwipeGestures.ts
@@ -1,7 +1,7 @@
-/**
- * Custom hook for detecting swipe gestures on touch devices
- */
 import { useEffect, useRef, useCallback } from 'react';
+
+// Always excluded from swipe detection — tapping these should never trigger a swipe.
+const INTERACTIVE_SELECTOR = 'button, a, input, select, textarea, [role="button"]';
 
 interface SwipeGestureOptions {
   minSwipeDistance?: number;
@@ -11,7 +11,8 @@ interface SwipeGestureOptions {
   onSwipeUp?: () => void;
   onSwipeDown?: () => void;
   preventDefault?: boolean;
-  excludeSelector?: string; // CSS selector for elements to exclude from swipe detection
+  // Additional selector to exclude on top of the built-in interactive-element exclusion.
+  excludeSelector?: string;
 }
 
 interface TouchPoint {
@@ -20,9 +21,16 @@ interface TouchPoint {
   timestamp: number;
 }
 
+function isExcluded(target: EventTarget | null, extraSelector?: string): boolean {
+  if (!(target instanceof Element)) return false;
+  if (target.closest(INTERACTIVE_SELECTOR)) return true;
+  if (extraSelector && target.closest(extraSelector)) return true;
+  return false;
+}
+
 export const useSwipeGestures = (
   elementRef: React.RefObject<HTMLElement | null>,
-  options: SwipeGestureOptions
+  options: SwipeGestureOptions,
 ) => {
   const {
     minSwipeDistance = 50,
@@ -31,122 +39,62 @@ export const useSwipeGestures = (
     onSwipeRight,
     onSwipeUp,
     onSwipeDown,
-    preventDefault = false, // Changed default to false for better mobile experience
-    excludeSelector
+    preventDefault = false,
+    excludeSelector,
   } = options;
 
   const touchStart = useRef<TouchPoint | null>(null);
   const isSwiping = useRef(false);
 
   const handleTouchStart = useCallback((e: TouchEvent) => {
-    // Check if touch started on excluded element
-    if (excludeSelector && e.target instanceof Element) {
-      if (e.target.closest(excludeSelector)) {
-        return; // Don't handle swipes on excluded elements
-      }
-    }
-    
-    if (preventDefault) {
-      e.preventDefault();
-    }
-    
+    if (isExcluded(e.target, excludeSelector)) return;
+    if (preventDefault) e.preventDefault();
     const touch = e.touches[0];
     if (touch) {
-      touchStart.current = {
-        x: touch.clientX,
-        y: touch.clientY,
-        timestamp: Date.now()
-      };
+      touchStart.current = { x: touch.clientX, y: touch.clientY, timestamp: Date.now() };
       isSwiping.current = false;
     }
   }, [preventDefault, excludeSelector]);
 
   const handleTouchMove = useCallback((e: TouchEvent) => {
-    // Check if touch is on excluded element
-    if (excludeSelector && e.target instanceof Element) {
-      if (e.target.closest(excludeSelector)) {
-        return;
-      }
-    }
-    
-    if (preventDefault) {
-      e.preventDefault();
-    }
-    
+    if (isExcluded(e.target, excludeSelector)) return;
+    if (preventDefault) e.preventDefault();
     if (!touchStart.current) return;
-    
     const touch = e.touches[0];
     if (touch) {
-      const deltaX = Math.abs(touch.clientX - touchStart.current.x);
-      const deltaY = Math.abs(touch.clientY - touchStart.current.y);
-      
-      // Start tracking swipe if movement is significant
-      if (deltaX > 10 || deltaY > 10) {
-        isSwiping.current = true;
-      }
+      const dx = Math.abs(touch.clientX - touchStart.current.x);
+      const dy = Math.abs(touch.clientY - touchStart.current.y);
+      if (dx > 10 || dy > 10) isSwiping.current = true;
     }
   }, [preventDefault, excludeSelector]);
 
   const handleTouchEnd = useCallback((e: TouchEvent) => {
-    // Check if touch ended on excluded element
-    if (excludeSelector && e.target instanceof Element) {
-      if (e.target.closest(excludeSelector)) {
-        touchStart.current = null;
-        isSwiping.current = false;
-        return;
-      }
-    }
-    
-    if (preventDefault) {
-      e.preventDefault();
-    }
-    
-    if (!touchStart.current || !isSwiping.current) {
+    if (isExcluded(e.target, excludeSelector)) {
       touchStart.current = null;
+      isSwiping.current = false;
       return;
     }
+    if (preventDefault) e.preventDefault();
+    if (!touchStart.current || !isSwiping.current) { touchStart.current = null; return; }
 
     const touch = e.changedTouches[0];
-    if (!touch) {
-      touchStart.current = null;
-      return;
-    }
+    if (!touch) { touchStart.current = null; return; }
 
-    const endTime = Date.now();
-    const timeDelta = endTime - touchStart.current.timestamp;
-    
-    // Check if swipe was fast enough
-    if (timeDelta > maxSwipeTime) {
+    if (Date.now() - touchStart.current.timestamp > maxSwipeTime) {
       touchStart.current = null;
       return;
     }
 
     const deltaX = touch.clientX - touchStart.current.x;
     const deltaY = touch.clientY - touchStart.current.y;
-    
-    const absDeltaX = Math.abs(deltaX);
-    const absDeltaY = Math.abs(deltaY);
+    const absDX = Math.abs(deltaX);
+    const absDY = Math.abs(deltaY);
 
-    // Check if swipe distance is sufficient
-    if (Math.max(absDeltaX, absDeltaY) < minSwipeDistance) {
-      touchStart.current = null;
-      return;
-    }
-
-    // Determine swipe direction
-    if (absDeltaX > absDeltaY) {
-      // Horizontal swipe
-      if (deltaX > 0) {
-        onSwipeRight?.();
+    if (Math.max(absDX, absDY) >= minSwipeDistance) {
+      if (absDX > absDY) {
+        deltaX > 0 ? onSwipeRight?.() : onSwipeLeft?.();
       } else {
-        onSwipeLeft?.();
-      }
-    } else {
-      // Vertical swipe
-      if (deltaY > 0) {
-        onSwipeDown?.();
-      } else {
-        onSwipeUp?.();
+        deltaY > 0 ? onSwipeDown?.() : onSwipeUp?.();
       }
     }
 
@@ -157,12 +105,10 @@ export const useSwipeGestures = (
   useEffect(() => {
     const element = elementRef.current;
     if (!element) return;
-
-    // Add touch event listeners
-    element.addEventListener('touchstart', handleTouchStart, { passive: !preventDefault });
-    element.addEventListener('touchmove', handleTouchMove, { passive: !preventDefault });
-    element.addEventListener('touchend', handleTouchEnd, { passive: !preventDefault });
-
+    const opts = { passive: !preventDefault };
+    element.addEventListener('touchstart', handleTouchStart, opts);
+    element.addEventListener('touchmove', handleTouchMove, opts);
+    element.addEventListener('touchend', handleTouchEnd, opts);
     return () => {
       element.removeEventListener('touchstart', handleTouchStart);
       element.removeEventListener('touchmove', handleTouchMove);


### PR DESCRIPTION
## What

- `useSwipeGestures` now auto-excludes `button, a, input, select, textarea, [role="button"]` from `preventDefault` and swipe tracking — no game ever needs a manual `excludeSelector` for interactive elements
- New `GameButton` component (exported from `src/components/ui`) — drop-in `<button>` that uses `onPointerDown + stopPropagation` internally so it's immune to ancestor non-passive touch handlers
- Snake migrated to `GameButton`; explicit `excludeSelector` removed (now redundant)
- `CLAUDE.md` created with platform docs: game structure, multiplayer pattern, touch rules, theming

## Why

The swipe fix in the previous PR was correct but game-specific. Any future game with buttons inside a swipe container would hit the same bug. This makes the correct behaviour the default at the platform level.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZSyiQENekom3uifApGQdN)_