### PR TITLE
Add bot support for Tic-Tac-Toe and Snake

### DIFF
--- a/src/components/game/GamesList.tsx
+++ b/src/components/game/GamesList.tsx
@@ -34,7 +34,7 @@ const AVAILABLE_GAMES: GameInfo[] = [
     description: 'Every player has their own snake. Eat food, grow long, survive.',
     icon: <Worm size={40} />,
     category: 'Arcade',
-    botSupported: false,
+    botSupported: true,
   },
   {
     id: 'game2048',
@@ -50,7 +50,7 @@ const AVAILABLE_GAMES: GameInfo[] = [
     description: 'Two randomly chosen players duel — everyone else watches!',
     icon: <Grid3X3 size={40} />,
     category: 'Strategy',
-    botSupported: false,
+    botSupported: true,
   },
   {
     id: 'uno',

--- a/src/games/snake/Snake.bot.ts
+++ b/src/games/snake/Snake.bot.ts
@@ -1,0 +1,114 @@
+import type { IBot, BotDifficulty } from '../_contract/IBot';
+import type { SnakeGameState, SnakeAction, Direction, Pos } from './types';
+
+const DIRS: Direction[] = ['up', 'down', 'left', 'right'];
+const OPPOSITE: Record<Direction, Direction> = { up: 'down', down: 'up', left: 'right', right: 'left' };
+
+function advance(pos: Pos, dir: Direction): Pos {
+  switch (dir) {
+    case 'up':    return { x: pos.x,     y: pos.y - 1 };
+    case 'down':  return { x: pos.x,     y: pos.y + 1 };
+    case 'left':  return { x: pos.x - 1, y: pos.y     };
+    case 'right': return { x: pos.x + 1, y: pos.y     };
+  }
+}
+
+function inBounds(pos: Pos, w: number, h: number): boolean {
+  return pos.x >= 0 && pos.x < w && pos.y >= 0 && pos.y < h;
+}
+
+function key(pos: Pos): string { return `${pos.x},${pos.y}`; }
+
+function occupiedSet(state: SnakeGameState): Set<string> {
+  const s = new Set<string>();
+  for (const snake of Object.values(state.snakes)) {
+    for (const seg of snake.segments) s.add(key(seg));
+  }
+  return s;
+}
+
+function safeDirs(head: Pos, current: Direction, occupied: Set<string>, w: number, h: number): Direction[] {
+  return DIRS.filter(d => {
+    if (d === OPPOSITE[current]) return false;
+    const next = advance(head, d);
+    return inBounds(next, w, h) && !occupied.has(key(next));
+  });
+}
+
+function bfsDir(head: Pos, target: Pos, current: Direction, occupied: Set<string>, w: number, h: number): Direction | null {
+  type Node = { pos: Pos; firstDir: Direction };
+  const visited = new Set<string>([key(head)]);
+  const queue: Node[] = [];
+
+  for (const d of DIRS) {
+    if (d === OPPOSITE[current]) continue;
+    const next = advance(head, d);
+    if (inBounds(next, w, h) && !occupied.has(key(next))) {
+      queue.push({ pos: next, firstDir: d });
+      visited.add(key(next));
+    }
+  }
+
+  while (queue.length > 0) {
+    const { pos, firstDir } = queue.shift()!;
+    if (pos.x === target.x && pos.y === target.y) return firstDir;
+
+    for (const d of DIRS) {
+      const next = advance(pos, d);
+      const k = key(next);
+      if (inBounds(next, w, h) && !occupied.has(k) && !visited.has(k)) {
+        visited.add(k);
+        queue.push({ pos: next, firstDir });
+      }
+    }
+  }
+  return null;
+}
+
+function nearestFood(head: Pos, food: Pos[]): Pos | null {
+  if (food.length === 0) return null;
+  return food.reduce((a, b) =>
+    Math.abs(a.x - head.x) + Math.abs(a.y - head.y) <=
+    Math.abs(b.x - head.x) + Math.abs(b.y - head.y) ? a : b,
+  );
+}
+
+class SnakeBotLogic implements IBot<SnakeGameState, SnakeAction> {
+  chooseAction(state: SnakeGameState, playerId: string, difficulty: BotDifficulty): SnakeAction {
+    const snake = state.snakes[playerId];
+    const fallback: SnakeAction = { type: 'change-direction', direction: snake?.nextDirection ?? 'right' };
+    if (!snake || !snake.alive) return fallback;
+
+    const head = snake.segments[0];
+    const current = snake.nextDirection;
+    const occupied = occupiedSet(state);
+    const safe = safeDirs(head, current, occupied, state.width, state.height);
+
+    if (difficulty === 'easy') {
+      if (safe.length === 0) return fallback;
+      if (safe.includes(current)) return { type: 'change-direction', direction: current };
+      return { type: 'change-direction', direction: safe[Math.floor(Math.random() * safe.length)] };
+    }
+
+    if (safe.length === 0) return fallback;
+
+    const target = nearestFood(head, state.food);
+    if (!target) return { type: 'change-direction', direction: safe[0] };
+
+    if (difficulty === 'medium') {
+      const best = safe.sort((a, b) => {
+        const na = advance(head, a);
+        const nb = advance(head, b);
+        return (Math.abs(na.x - target.x) + Math.abs(na.y - target.y)) -
+               (Math.abs(nb.x - target.x) + Math.abs(nb.y - target.y));
+      })[0];
+      return { type: 'change-direction', direction: best };
+    }
+
+    // Hard: BFS path to nearest food
+    const dir = bfsDir(head, target, current, occupied, state.width, state.height);
+    return { type: 'change-direction', direction: dir ?? safe[0] };
+  }
+}
+
+export const snakeBot = new SnakeBotLogic();

--- a/src/games/snake/Snake.tsx
+++ b/src/games/snake/Snake.tsx
@@ -2,9 +2,11 @@ import React, { useEffect, useRef, useCallback, useState } from 'react';
 import { useSession } from '../../hooks/useSession';
 import { useCoinService } from '../../hooks/useCoinService';
 import { useSwipeGestures } from '../../hooks/useSwipeGestures';
+import { useBots } from '../../hooks/useBots';
 import { GameButton } from '../../components/ui';
 import type { SnakeGameState, SnakeAction, Direction } from './types';
 import { snakeGame } from './Snake.game';
+import { snakeBot } from './Snake.bot';
 import {
   GRID_W, GRID_H, FOOD_COUNT, TICK_MS, DEAD_FADE_TICKS,
   pickRandomPositions, generateSnakeStarts, darken,
@@ -50,6 +52,9 @@ export const SnakeGame: React.FC<SnakeProps> = ({ playerId, playerName }) => {
   const isInSession = session.isInSession;
   const isHost = !isInSession || session.role === 'host';
   const localPlayer = session.localPlayer ?? { id: playerId, name: playerName, joinedAt: Date.now() };
+  const { bots } = useBots();
+  const botsRef = useRef(bots);
+  useEffect(() => { botsRef.current = bots; }, [bots]);
 
   const [displayState, setDisplayState] = useState<SnakeGameState>(() =>
     snakeGame.initialState([localPlayer]),
@@ -102,8 +107,17 @@ export const SnakeGame: React.FC<SnakeProps> = ({ playerId, playerName }) => {
         tickRef.current = null;
         return;
       }
-      const newFood = pickRandomPositions(FOOD_COUNT, cur.snakes, cur.food, cur.width, cur.height);
-      const next = snakeGame.reduce(cur, { type: 'tick', newFood }, localPlayer);
+
+      let state = cur;
+      for (const bot of botsRef.current) {
+        if (!state.snakes[bot.id]?.alive) continue;
+        const action = snakeBot.chooseAction(state, bot.id, bot.difficulty);
+        const withDir = snakeGame.reduce(state, action, { id: bot.id, name: bot.name, joinedAt: 0 });
+        if (withDir) state = withDir;
+      }
+
+      const newFood = pickRandomPositions(FOOD_COUNT, state.snakes, state.food, state.width, state.height);
+      const next = snakeGame.reduce(state, { type: 'tick', newFood }, localPlayer);
       if (!next) return;
       gameStateRef.current = next;
       setDisplayState(next);
@@ -114,9 +128,11 @@ export const SnakeGame: React.FC<SnakeProps> = ({ playerId, playerName }) => {
   // ── Start / new game ───────────────────────────────────────────────────
 
   const handleStart = useCallback(() => {
-    const allPlayers = isInSession
+    const humanPlayers = isInSession
       ? [localPlayer, ...session.peers]
       : [localPlayer];
+    const botPlayers = botsRef.current.map(b => ({ id: b.id, name: b.name, joinedAt: 0 as const }));
+    const allPlayers = [...humanPlayers, ...botPlayers];
 
     const snakeStarts = generateSnakeStarts(allPlayers, GRID_W, GRID_H);
     const food = pickRandomPositions(FOOD_COUNT, {}, [], GRID_W, GRID_H);

--- a/src/games/snake/index.ts
+++ b/src/games/snake/index.ts
@@ -1,3 +1,4 @@
 export { SnakeGame } from './Snake';
 export { snakeGame } from './Snake.game';
+export { snakeBot } from './Snake.bot';
 export type { SnakeGameState, SnakeAction } from './types';

--- a/src/games/tic-tac-toe/TicTacToe.bot.ts
+++ b/src/games/tic-tac-toe/TicTacToe.bot.ts
@@ -1,0 +1,64 @@
+import type { IBot, BotDifficulty } from '../_contract/IBot';
+import type { TicTacToeGameData } from './types';
+import type { TicTacToeAction } from './TicTacToe.game';
+import {
+  getPossibleMoves,
+  makeMove,
+  checkWinnerWithCombination,
+  getGameStatusWithCombination,
+} from './gameLogic';
+import type { Board } from './types';
+
+type Sym = 'X' | 'O';
+
+function findWinningMove(board: Board, sym: Sym): TicTacToeAction | null {
+  for (const move of getPossibleMoves(board)) {
+    const { winner } = checkWinnerWithCombination(makeMove(board, move.row, move.col, sym));
+    if (winner === sym) return move;
+  }
+  return null;
+}
+
+function minimax(board: Board, botSym: Sym, currentSym: Sym, depth: number): { score: number; move?: TicTacToeAction } {
+  const humanSym: Sym = botSym === 'X' ? 'O' : 'X';
+  const { status } = getGameStatusWithCombination(board);
+  if (status === `${botSym}-wins`) return { score: 10 - depth };
+  if (status === `${humanSym}-wins`) return { score: depth - 10 };
+  if (status === 'tie') return { score: 0 };
+
+  const moves = getPossibleMoves(board);
+  const nextSym: Sym = currentSym === 'X' ? 'O' : 'X';
+  const isMax = currentSym === botSym;
+  let best = { score: isMax ? -Infinity : Infinity, move: moves[0] };
+
+  for (const move of moves) {
+    const { score } = minimax(makeMove(board, move.row, move.col, currentSym), botSym, nextSym, depth + 1);
+    if (isMax ? score > best.score : score < best.score) best = { score, move };
+  }
+  return best;
+}
+
+class TicTacToeBotLogic implements IBot<TicTacToeGameData, TicTacToeAction> {
+  chooseAction(state: TicTacToeGameData, playerId: string, difficulty: BotDifficulty): TicTacToeAction {
+    const moves = getPossibleMoves(state.board);
+    if (moves.length === 0) return { row: 0, col: 0 };
+
+    const botSym: Sym = state.multiplayer.xPlayerId === playerId ? 'X' : 'O';
+    const humanSym: Sym = botSym === 'X' ? 'O' : 'X';
+
+    if (difficulty === 'easy') return moves[Math.floor(Math.random() * moves.length)];
+
+    if (difficulty === 'medium') {
+      const win = findWinningMove(state.board, botSym);
+      if (win) return win;
+      const block = findWinningMove(state.board, humanSym);
+      if (block) return block;
+      if (state.board[1][1] === null) return { row: 1, col: 1 };
+      return moves[Math.floor(Math.random() * moves.length)];
+    }
+
+    return minimax(state.board, botSym, state.currentPlayer, 0).move ?? moves[0];
+  }
+}
+
+export const ticTacToeBot = new TicTacToeBotLogic();

--- a/src/games/tic-tac-toe/TicTacToeGame.tsx
+++ b/src/games/tic-tac-toe/TicTacToeGame.tsx
@@ -2,8 +2,11 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useGameSave } from '../../hooks/useGameSave';
 import { useCoinService } from '../../hooks/useCoinService';
 import { useGameAction, useGameSnapshot, useSession } from '../../hooks/useSession';
+import { useBots } from '../../hooks/useBots';
+import { useBotRunner } from '../../hooks/useBotRunner';
 import { TicTacToeGameController } from './controller';
 import { ticTacToeGame, buildInitialStats, type TicTacToeAction } from './TicTacToe.game';
+import { ticTacToeBot } from './TicTacToe.bot';
 import type { TicTacToeGameData } from './types';
 import type { Player } from '../../core';
 import './TicTacToeGame.css';
@@ -21,6 +24,8 @@ export const TicTacToeGame: React.FC<TicTacToeGameProps> = ({ playerId, playerNa
   const isInSession = session.isInSession;
   const isHost = session.role === 'host';
   const localPeer = session.localPlayer;
+  const { bots } = useBots();
+  const isHostForBots = !isInSession || isHost;
 
   const {
     gameState,
@@ -70,6 +75,8 @@ export const TicTacToeGame: React.FC<TicTacToeGameProps> = ({ playerId, playerNa
       lastModified: new Date().toISOString(),
     });
   }, [setGameState, awardGameCompletion]);
+
+  useBotRunner(bots, gameState.data, ticTacToeGame, ticTacToeBot, isHostForBots, applyAction);
 
   // ── Receive remote actions ────────────────────────────────────────────────
 
@@ -137,9 +144,12 @@ export const TicTacToeGame: React.FC<TicTacToeGameProps> = ({ playerId, playerNa
     const stats = buildInitialStats(current.data);
     const wasPlaying = current.data.gameStatus !== 'playing';
 
+    const botPlayers = bots.slice(0, 1).map(b => ({ id: b.id, name: b.name, joinedAt: 0 as const }));
     const players: Player[] = isInSession && localPeer
       ? [localPeer, ...session.peers]
-      : [];
+      : botPlayers.length > 0
+        ? [{ id: playerId, name: playerName, joinedAt: Date.now() }, ...botPlayers]
+        : [];
 
     const fresh = ticTacToeGame.initialState(players);
     const newData = { ...fresh, ...stats };

--- a/src/games/tic-tac-toe/index.ts
+++ b/src/games/tic-tac-toe/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { TicTacToeGame, default } from './TicTacToeGame';
+export { ticTacToeBot } from './TicTacToe.bot';
 export { TicTacToeGameController } from './controller';
 export type { 
   TicTacToeGameData, 


### PR DESCRIPTION
Implements `IBot` for both games so the Bot button in the nav actually works for them.

## Tic-Tac-Toe (`TicTacToe.bot.ts`)
Uses `useBotRunner` (turn-based, `canAct` gates it correctly):
- **Easy** — random valid move
- **Medium** — win if possible → block opponent's win → take center → random
- **Hard** — full minimax (optimal play, never loses)

`handleNewGame` updated to include the first bot as the second player in solo mode. With a bot present, `initialState([human, bot])` sets `isMultiplayer: true` so turn enforcement works correctly.

## Snake (`Snake.bot.ts`)
Real-time tick-driven game — `useBotRunner`'s thinking delays (500–1800ms) would make bots act once every 3–10 ticks. Bot logic runs **inside the `setInterval` tick loop** instead, deciding direction every 150ms just before the tick is applied:
- **Easy** — hold current direction if safe, else pick a random safe direction
- **Medium** — greedy: sort safe directions by Manhattan distance to nearest food
- **Hard** — BFS shortest path to nearest food avoiding all occupied cells

Both bots added to `handleStart` via `botsRef` so bots get snake starts generated alongside human players.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZSyiQENekom3uifApGQdN)_